### PR TITLE
When no factset identifier is supplied

### DIFF
--- a/roles/roles_service.go
+++ b/roles/roles_service.go
@@ -3,6 +3,7 @@ package roles
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/Financial-Times/neo-utils-go/neoutils"
 	"github.com/jmcvetta/neoism"
 )
@@ -134,7 +135,9 @@ func (pcd CypherDriver) Write(thing interface{}) error {
 		queryBatch = append(queryBatch, alternativeIdentifierQuery)
 	}
 
-	queryBatch = append(queryBatch, createNewIdentifierQuery(roleToWrite.UUID, factsetIdentifierLabel, roleToWrite.AlternativeIdentifiers.FactsetIdentifier))
+	if roleToWrite.AlternativeIdentifiers.FactsetIdentifier != "" {
+		queryBatch = append(queryBatch, createNewIdentifierQuery(roleToWrite.UUID, factsetIdentifierLabel, roleToWrite.AlternativeIdentifiers.FactsetIdentifier))
+	}
 
 	return pcd.cypherRunner.CypherBatch([]*neoism.CypherQuery(queryBatch))
 }

--- a/roles/roles_service_test.go
+++ b/roles/roles_service_test.go
@@ -51,6 +51,21 @@ func TestCreateAllValuesPresent(t *testing.T) {
 	cleanUp(t, uuid)
 }
 
+func TestCreateNoFacsetIdentifierPresent(t *testing.T) {
+	assert := assert.New(t)
+	uuid := "12345"
+	rolesDriver = getRolesCypherDriver(t)
+
+	altId := alternativeIdentifiers{UUIDS: []string{"UUID"}}
+	roleToWrite := role{UUID: uuid, PrefLabel: "TestRole", AlternativeIdentifiers: altId}
+
+	assert.NoError(rolesDriver.Write(roleToWrite), "Failed to write role")
+
+	readRoleForUUIDAndCheckFieldsMatch(t, uuid, roleToWrite)
+
+	cleanUp(t, uuid)
+}
+
 func TestCreateHandlesSpecialCharacters(t *testing.T) {
 	assert := assert.New(t)
 	uuid := "12345"

--- a/roles/roles_service_test.go
+++ b/roles/roles_service_test.go
@@ -51,7 +51,7 @@ func TestCreateAllValuesPresent(t *testing.T) {
 	cleanUp(t, uuid)
 }
 
-func TestCreateNoFacsetIdentifierPresent(t *testing.T) {
+func TestCreateNoFactsetIdentifierPresent(t *testing.T) {
 	assert := assert.New(t)
 	uuid := "12345"
 	rolesDriver = getRolesCypherDriver(t)


### PR DESCRIPTION
e.g. for FT roles Journalist and Columnist, don't write a factset identifier node
